### PR TITLE
Direct chapter two readers towards using adt explorer

### DIFF
--- a/docs/onboarding/02-digital-twin-definition-language.md
+++ b/docs/onboarding/02-digital-twin-definition-language.md
@@ -4,10 +4,6 @@ DTDL is the schema by which models are described. Its important to understand ho
 
 - [Concepts](https://docs.microsoft.com/en-us/azure/digital-twins/concepts-models) - ~11 min. Covers basic concepts of DTDL language
 - [Marker tags](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-use-tags) ~10 min. Covers how to define tags, how to provision tag markers to your twins and how to query filtering by tags.
-
-
-> Model management is especially important for understanding what a CI/CD pipeline for ADT models might need to include.
-
 - [Ontologies](https://docs.microsoft.com/en-us/azure/digital-twins/concepts-ontologies) - ~3 min. Covers definition and use cases for ontologies: domain-specific sets of models.
 - [Brick](https://docs.brickschema.org/intro.html) - Alternative to DTDL and some other aspects of Azure Digital Twins.
 

--- a/docs/onboarding/02-digital-twin-definition-language.md
+++ b/docs/onboarding/02-digital-twin-definition-language.md
@@ -4,7 +4,7 @@ DTDL is the schema by which models are described. Its important to understand ho
 
 - [Concepts](https://docs.microsoft.com/en-us/azure/digital-twins/concepts-models) - ~11 min. Covers basic concepts of DTDL language
 - [Marker tags](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-use-tags) ~10 min. Covers how to define tags, how to provision tag markers to your twins and how to query filtering by tags.
-- [Model Management](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-manage-model) - ~11 min. Covers how to deploy models to ADT including creating, updates, and removal.
+
 
 > Model management is especially important for understanding what a CI/CD pipeline for ADT models might need to include.
 
@@ -22,7 +22,9 @@ DTDL is the schema by which models are described. Its important to understand ho
 
 ## Learning Exercises
 
-The following exercises involve creating and modifying models using DTDL. The models can be updated via the [Azure Digital Twins Explorer](https://docs.microsoft.com/en-us/azure/digital-twins/quickstart-adt-explorer) or [Azure Digital Twins CLI](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-use-cli).
+The following exercises involve creating and modifying models using DTDL.
+
+> Important! The models can be updated via the [Azure Digital Twins Explorer](https://docs.microsoft.com/en-us/azure/digital-twins/quickstart-adt-explorer) or [Azure Digital Twins CLI](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-use-cli). Its encouraged to complete the exercises using Azure Digital Twins Explorer as it will visualize the changes made in the exercise.
 
 ### Create a new model
 
@@ -38,8 +40,9 @@ The following exercises involve creating and modifying models using DTDL. The mo
 3. Create a new twin using the updated model.
 
 ### Add a marker tag
+
 1. Modify your first model to include a marker tag.
-2. Upload the updated model as a new version. 
+2. Upload the updated model as a new version.
 3. Create new twin using the updated model.
 4. Update the tag value of the twin.
 5. Perform a query to get results filtering by your tag.
@@ -49,6 +52,7 @@ The following exercises involve creating and modifying models using DTDL. The mo
 1. Create a new second model.
 2. Update the models such that the first and second model are related
 3. Upload the models that were updated to establish the relationship.
+
 > Tip: The keyword `target` enables you to target a specific class for that relationship "name". For instance, for model RoundHole, if you set the following:
 > ```json
 > {

--- a/docs/onboarding/03-sdks-and-apis.md
+++ b/docs/onboarding/03-sdks-and-apis.md
@@ -4,6 +4,9 @@ Azure digital twins provides an SDK for multiple languages for programmatic mana
 
 - [Use the APIs and SDKs](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-use-apis-sdks)
 - [Create Graph with the APIs](https://docs.microsoft.com/en-us/azure/digital-twins/concepts-twins-graph#create-with-the-apis)
+- [Model Management](https://docs.microsoft.com/en-us/azure/digital-twins/how-to-manage-model) - ~11 min. Covers how to deploy models to ADT including creating, updates, and removal.
+
+> Model management is especially important for understanding what a CI/CD pipeline for ADT models might need to include.
 
 ## Key Points
 


### PR DESCRIPTION
The following are changes discussed with one of the teams to help direct others towards using ADT Explorer to complete the chapter 2 exercises rather than the sdk or api's.

- moved model management to chapter 3 as it has lots of code examples. this gave one of the team members the impression that chapter 2 should be completed with .net sdk
- called out use of adt explorer more explicitly in the exercises